### PR TITLE
:sparkles: Add DLLoader class to load libraries and get object instances

### DIFF
--- a/include/core/DLLoader.hpp
+++ b/include/core/DLLoader.hpp
@@ -1,0 +1,40 @@
+/*
+** EPITECH PROJECT, 2024
+** Arcade
+** File description:
+** DLLoader
+*/
+
+#pragma once
+
+#include <dlfcn.h>
+#include <iostream>
+
+template <typename T>
+class DLLoader {
+public:
+    DLLoader(std::string const &libPath) {
+        this->_handle = dlopen(libPath.c_str(), RTLD_LAZY);
+        if (!this->_handle) {
+            std::cerr << "Cannot open library: " << dlerror() << '\n';
+            exit(84); // Replace with exception
+        }
+        this->_entryPoint = reinterpret_cast<T *(*)()>(dlsym(this->_handle, "entryPoint"));
+        if (!this->_entryPoint) {
+            std::cerr << "Cannot load symbol entryPoint: " << dlerror() << '\n';
+            exit(84); // Replace with exception
+        }
+    }
+
+    ~DLLoader() {
+        dlclose(this->_handle);
+    }
+
+    T *getInstance() {
+        return this->_entryPoint();
+    }
+
+private:
+    void *_handle;
+    T *(*_entryPoint)();
+};


### PR DESCRIPTION
Create a DLLoader class to encapsulate the functions offered by libdl within an object. With this class, you can load libraries and get object instances from them.

Issue linked : 
- close #15 